### PR TITLE
Fix: Normalize separator line lengths

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ https://github.com/user-attachments/assets/ed8e6942-fbd0-44d0-8f35-fcb1c9cdb6fb
 
 ```lua
 {
-  'carlosalarconb/marko.nvim',
+  'developedbyed/marko.nvim',
   config = function()
     require('marko').setup({
       width = 100,
@@ -40,7 +40,7 @@ https://github.com/user-attachments/assets/ed8e6942-fbd0-44d0-8f35-fcb1c9cdb6fb
 
 ```lua
 use {
-  'carlosalarconb/marko.nvim',
+  'developedbyed/marko.nvim',
   config = function()
     require('marko').setup()
   end
@@ -50,7 +50,7 @@ use {
 ### Using [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```vim
-Plug 'carlosalarconb/marko.nvim'
+Plug 'developedbyed/marko.nvim'
 ```
 
 ## Usage
@@ -58,15 +58,18 @@ Plug 'carlosalarconb/marko.nvim'
 ### Basic Usage
 
 1. **Set marks** in your files:
+
    ```vim
    ma    " Set buffer mark 'a'
    mA    " Set global mark 'A'
    ```
 
 2. **Open the marks popup**:
+
    ```vim
    :Marko
    ```
+
    Or use the default keymap: `"`
 
 3. **Navigate in the popup**:
@@ -82,7 +85,7 @@ Direct mode allows instant mark jumping without cursor navigation. The popup dis
 
 1. **Enable direct mode**:
    - Press `;` in the popup, or
-   - Use command: `:MarkoDirectMode`, or 
+   - Use command: `:MarkoDirectMode`, or
    - Use the configured toggle keymap
 
 2. **Navigate directly** (popup must remain open):
@@ -99,6 +102,7 @@ Direct mode allows instant mark jumping without cursor navigation. The popup dis
 ### Virtual Text
 
 When enabled, marks are displayed as virtual text in your code:
+
 - Set a mark with `ma`, `mB`, etc. and see the indicator appear immediately
 - Virtual text shows both buffer marks (blue) and global marks (red)
 - Toggle virtual text on/off with `:MarkoToggleVirtual`
@@ -110,19 +114,19 @@ require('marko').setup({
   -- Popup window dimensions
   width = 100,
   height = 100,
-  
+
   -- Border style: 'rounded', 'single', 'double', 'solid', 'shadow'
   border = "rounded",
-  
+
   -- Popup title
   title = " Marks ",
-  
+
   -- Default keymap to open popup (set to false to disable)
   default_keymap = '"',
-  
+
   -- Navigation mode: "popup" (default) or "direct" (jump directly to marks)
   navigation_mode = "popup",
-  
+
   -- Key mappings within popup
   -- Can be a single key (string) or multiple keys (table of strings)
   keymaps = {
@@ -130,18 +134,18 @@ require('marko').setup({
     goto = { "<CR>", "o" }, -- Example of multiple keys
     close = { "<Esc>", "q" },
   },
-  
+
   -- Direct mode configuration
   direct_mode = {
     mode_toggle_key = "<leader>mm", -- Key to toggle modes
   },
-  
+
   -- Show marks from all buffers or just current buffer
   show_all_buffers = false,
-  
+
   -- Exclude certain marks from display
   exclude_marks = { "'", "`", "^", ".", "[", "]", "<", ">" },
-  
+
   -- Virtual text configuration
   virtual_text = {
     enabled = true,        -- Enable virtual text marks
@@ -187,20 +191,20 @@ vim.cmd([[
 
 ## Commands
 
-| Command | Description |
-|---------|-------------|
-| `:Marko` | Open the marks popup |
-| `:MarkoToggleVirtual` | Toggle virtual text marks on/off |
-| `:MarkoToggleMode` | Toggle between popup and direct navigation modes |
-| `:MarkoDirectMode` | Enable direct navigation mode |
-| `:MarkoPopupMode` | Enable popup navigation mode |
+| Command               | Description                                      |
+| --------------------- | ------------------------------------------------ |
+| `:Marko`              | Open the marks popup                             |
+| `:MarkoToggleVirtual` | Toggle virtual text marks on/off                 |
+| `:MarkoToggleMode`    | Toggle between popup and direct navigation modes |
+| `:MarkoDirectMode`    | Enable direct navigation mode                    |
+| `:MarkoPopupMode`     | Enable popup navigation mode                     |
 
 ## Mark Quick Reference
 
-| Mark | Type | Scope | Persistence |
-|------|------|-------|-------------|
+| Mark  | Type   | Scope               | Persistence             |
+| ----- | ------ | ------------------- | ----------------------- |
 | `a-z` | Buffer | Current buffer only | Lost when buffer closes |
-| `A-Z` | Global | Across all files | Saved in shada file |
+| `A-Z` | Global | Across all files    | Saved in shada file     |
 
 ## Contributing
 
@@ -224,5 +228,5 @@ MIT License - see [LICENSE](LICENSE) file for details.
 ## Acknowledgments
 
 - Built for the Neovim community
-- Inspired by vim's built-in marks system  
+- Inspired by vim's built-in marks system
 - Uses Neovim's modern Lua API

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ https://github.com/user-attachments/assets/ed8e6942-fbd0-44d0-8f35-fcb1c9cdb6fb
 
 ```lua
 {
-  'developedbyed/marko.nvim',
+  'carlosalarconb/marko.nvim',
   config = function()
     require('marko').setup({
       width = 100,
@@ -40,7 +40,7 @@ https://github.com/user-attachments/assets/ed8e6942-fbd0-44d0-8f35-fcb1c9cdb6fb
 
 ```lua
 use {
-  'developedbyed/marko.nvim',
+  'carlosalarconb/marko.nvim',
   config = function()
     require('marko').setup()
   end
@@ -50,7 +50,7 @@ use {
 ### Using [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```vim
-Plug 'developedbyed/marko.nvim'
+Plug 'carlosalarconb/marko.nvim'
 ```
 
 ## Usage
@@ -58,18 +58,15 @@ Plug 'developedbyed/marko.nvim'
 ### Basic Usage
 
 1. **Set marks** in your files:
-
    ```vim
    ma    " Set buffer mark 'a'
    mA    " Set global mark 'A'
    ```
 
 2. **Open the marks popup**:
-
    ```vim
    :Marko
    ```
-
    Or use the default keymap: `"`
 
 3. **Navigate in the popup**:
@@ -85,7 +82,7 @@ Direct mode allows instant mark jumping without cursor navigation. The popup dis
 
 1. **Enable direct mode**:
    - Press `;` in the popup, or
-   - Use command: `:MarkoDirectMode`, or
+   - Use command: `:MarkoDirectMode`, or 
    - Use the configured toggle keymap
 
 2. **Navigate directly** (popup must remain open):
@@ -102,7 +99,6 @@ Direct mode allows instant mark jumping without cursor navigation. The popup dis
 ### Virtual Text
 
 When enabled, marks are displayed as virtual text in your code:
-
 - Set a mark with `ma`, `mB`, etc. and see the indicator appear immediately
 - Virtual text shows both buffer marks (blue) and global marks (red)
 - Toggle virtual text on/off with `:MarkoToggleVirtual`
@@ -114,19 +110,19 @@ require('marko').setup({
   -- Popup window dimensions
   width = 100,
   height = 100,
-
+  
   -- Border style: 'rounded', 'single', 'double', 'solid', 'shadow'
   border = "rounded",
-
+  
   -- Popup title
   title = " Marks ",
-
+  
   -- Default keymap to open popup (set to false to disable)
   default_keymap = '"',
-
+  
   -- Navigation mode: "popup" (default) or "direct" (jump directly to marks)
   navigation_mode = "popup",
-
+  
   -- Key mappings within popup
   -- Can be a single key (string) or multiple keys (table of strings)
   keymaps = {
@@ -134,18 +130,18 @@ require('marko').setup({
     goto = { "<CR>", "o" }, -- Example of multiple keys
     close = { "<Esc>", "q" },
   },
-
+  
   -- Direct mode configuration
   direct_mode = {
     mode_toggle_key = "<leader>mm", -- Key to toggle modes
   },
-
+  
   -- Show marks from all buffers or just current buffer
   show_all_buffers = false,
-
+  
   -- Exclude certain marks from display
   exclude_marks = { "'", "`", "^", ".", "[", "]", "<", ">" },
-
+  
   -- Virtual text configuration
   virtual_text = {
     enabled = true,        -- Enable virtual text marks
@@ -191,20 +187,20 @@ vim.cmd([[
 
 ## Commands
 
-| Command               | Description                                      |
-| --------------------- | ------------------------------------------------ |
-| `:Marko`              | Open the marks popup                             |
-| `:MarkoToggleVirtual` | Toggle virtual text marks on/off                 |
-| `:MarkoToggleMode`    | Toggle between popup and direct navigation modes |
-| `:MarkoDirectMode`    | Enable direct navigation mode                    |
-| `:MarkoPopupMode`     | Enable popup navigation mode                     |
+| Command | Description |
+|---------|-------------|
+| `:Marko` | Open the marks popup |
+| `:MarkoToggleVirtual` | Toggle virtual text marks on/off |
+| `:MarkoToggleMode` | Toggle between popup and direct navigation modes |
+| `:MarkoDirectMode` | Enable direct navigation mode |
+| `:MarkoPopupMode` | Enable popup navigation mode |
 
 ## Mark Quick Reference
 
-| Mark  | Type   | Scope               | Persistence             |
-| ----- | ------ | ------------------- | ----------------------- |
+| Mark | Type | Scope | Persistence |
+|------|------|-------|-------------|
 | `a-z` | Buffer | Current buffer only | Lost when buffer closes |
-| `A-Z` | Global | Across all files    | Saved in shada file     |
+| `A-Z` | Global | Across all files | Saved in shada file |
 
 ## Contributing
 
@@ -228,5 +224,5 @@ MIT License - see [LICENSE](LICENSE) file for details.
 ## Acknowledgments
 
 - Built for the Neovim community
-- Inspired by vim's built-in marks system
+- Inspired by vim's built-in marks system  
 - Uses Neovim's modern Lua API

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ https://github.com/user-attachments/assets/ed8e6942-fbd0-44d0-8f35-fcb1c9cdb6fb
 
 ```lua
 {
-  'developedbyed/marko.nvim',
+  'carlosalarconb/marko.nvim',
   config = function()
     require('marko').setup({
       width = 100,
@@ -40,7 +40,7 @@ https://github.com/user-attachments/assets/ed8e6942-fbd0-44d0-8f35-fcb1c9cdb6fb
 
 ```lua
 use {
-  'developedbyed/marko.nvim',
+  'carlosalarconb/marko.nvim',
   config = function()
     require('marko').setup()
   end
@@ -50,7 +50,7 @@ use {
 ### Using [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```vim
-Plug 'developedbyed/marko.nvim'
+Plug 'carlosalarconb/marko.nvim'
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ https://github.com/user-attachments/assets/ed8e6942-fbd0-44d0-8f35-fcb1c9cdb6fb
 
 ```lua
 {
-  'carlosalarconb/marko.nvim',
+  'developedbyed/marko.nvim',
   config = function()
     require('marko').setup({
       width = 100,
@@ -40,7 +40,7 @@ https://github.com/user-attachments/assets/ed8e6942-fbd0-44d0-8f35-fcb1c9cdb6fb
 
 ```lua
 use {
-  'carlosalarconb/marko.nvim',
+  'developedbyed/marko.nvim',
   config = function()
     require('marko').setup()
   end
@@ -50,7 +50,7 @@ use {
 ### Using [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```vim
-Plug 'carlosalarconb/marko.nvim'
+Plug 'developedbyed/marko.nvim'
 ```
 
 ## Usage

--- a/lua/marko/popup.lua
+++ b/lua/marko/popup.lua
@@ -9,6 +9,17 @@ function M.is_open()
   return popup_win and vim.api.nvim_win_is_valid(popup_win)
 end
 
+local function get_separator_line()
+  local config = require("marko.config").get()
+  local width = config.width
+
+  if width < 80 then
+    width = 80
+  end
+
+  return string.rep("─", width)
+end
+
 -- Create shadow window for depth effect
 local function create_shadow(width, height, row, col)
   if not require("marko.config").get().shadow then
@@ -139,7 +150,7 @@ local function generate_header(marks)
     "",  -- Empty line for spacing
     mode_line,  -- Mode indicator line
     stats,
-    string.rep("─", 80),  -- Separator line (wider for better coverage)
+    get_separator_line(),
   }
 end
 
@@ -159,7 +170,7 @@ local function generate_column_headers()
   
   return {
     header_line,
-    string.rep("─", 80),  -- Separator line
+    get_separator_line(),
   }
 end
 
@@ -180,7 +191,7 @@ local function generate_status_bar()
   end
   
   return {
-    string.rep("─", 60),  -- Separator line
+    get_separator_line(),
     status_text,
     ""  -- Empty line for spacing
   }


### PR DESCRIPTION
There were some separators with different lengths. They are fixed according to the window width