### PR TITLE
Fix goto reserved keyword

### DIFF
--- a/lua/marko/config.lua
+++ b/lua/marko/config.lua
@@ -11,7 +11,7 @@ local default_config = {
   navigation_mode = "popup",
   keymaps = {
     delete = "d",
-    goto = "<CR>",
+    ["goto"] = "<CR>",
     close = "<Esc>",
   },
   -- Direct mode configuration

--- a/lua/marko/popup.lua
+++ b/lua/marko/popup.lua
@@ -436,7 +436,7 @@ function M.setup_keymaps()
       marks_module.goto_mark(marks_data[mark_index])
     end
   end
-  set_keymaps(config.keymaps.goto, goto_func)
+  set_keymaps(config.keymaps["goto"], goto_func)
 
   -- Delete mark
   local delete_func = function()


### PR DESCRIPTION
Fixes Lua syntax error caused by using `goto` as an unquoted table key.

`goto` is a reserved keyword in Lua 5.2+, causing parse errors on newer Neovim installations. Changed to bracket notation `["goto"]` which is backward compatible.

**Changes:**
- `lua/marko/config.lua`: Quote `goto` key in keymaps table
- `lua/marko/popup.lua`: Use bracket notation to access `goto` keymap

**Tested on:**
- Fedora with Neovim (Lua 5.2+)
- Backward compatible with existing configurations
